### PR TITLE
Fix passkey redirect

### DIFF
--- a/services/dev/handlers.go
+++ b/services/dev/handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/datasektionen/logout/pkg/httputil"
+	"github.com/datasektionen/logout/services/user/auth"
 )
 
 func (s *service) login(w http.ResponseWriter, r *http.Request) httputil.ToResponse {
@@ -19,7 +20,7 @@ func (s *service) login(w http.ResponseWriter, r *http.Request) httputil.ToRespo
 		return err
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name:  "session",
+		Name:  auth.SESSION_COOKIE,
 		Value: sessionID.String(),
 		Path:  "/",
 	})

--- a/services/dev/handlers.go
+++ b/services/dev/handlers.go
@@ -20,7 +20,7 @@ func (s *service) login(w http.ResponseWriter, r *http.Request) httputil.ToRespo
 		return err
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name:  auth.SESSION_COOKIE,
+		Name:  auth.SessionCookieName,
 		Value: sessionID.String(),
 		Path:  "/",
 	})

--- a/services/passkey/handlers.go
+++ b/services/passkey/handlers.go
@@ -73,7 +73,7 @@ func (s *service) finishLoginPasskey(w http.ResponseWriter, r *http.Request) htt
 		return err
 	}
 
-	http.SetCookie(w, auth.UserCookie(sessionID.String()))
+	http.SetCookie(w, auth.SessionCookie(sessionID.String()))
 
 	return nil
 }

--- a/services/passkey/handlers.go
+++ b/services/passkey/handlers.go
@@ -73,14 +73,7 @@ func (s *service) finishLoginPasskey(w http.ResponseWriter, r *http.Request) htt
 		return err
 	}
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     auth.SESSION_COOKIE,
-		Value:    sessionID.String(),
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	http.SetCookie(w, auth.UserCookie(sessionID.String()))
 
 	return nil
 }

--- a/services/passkey/handlers.go
+++ b/services/passkey/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/datasektionen/logout/pkg/database"
 	"github.com/datasektionen/logout/pkg/httputil"
 	"github.com/datasektionen/logout/services/passkey/export"
+	"github.com/datasektionen/logout/services/user/auth"
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/google/uuid"
@@ -73,7 +74,7 @@ func (s *service) finishLoginPasskey(w http.ResponseWriter, r *http.Request) htt
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     "session",
+		Name:     auth.SESSION_COOKIE,
 		Value:    sessionID.String(),
 		Path:     "/",
 		HttpOnly: true,

--- a/services/passkey/passkey.templ
+++ b/services/passkey/passkey.templ
@@ -25,7 +25,6 @@ templ passkeyLogin(kthid string, credAss *protocol.CredentialAssertion) {
 				for (let ac of credAss.publicKey.allowCredentials) {
 					ac.id = decodebase64url(ac.id);
 				}
-				console.log(credAss);
 				event.preventDefault();
 				try {
 					let cred = await navigator.credentials.get(credAss);

--- a/services/passkey/passkey_templ.go
+++ b/services/passkey/passkey_templ.go
@@ -60,7 +60,7 @@ func passkeyLogin(kthid string, credAss *protocol.CredentialAssertion) templ.Com
 			return templ_7745c5c3_Err
 		}
 		if credAss != nil {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<script type=\"module\">\n\t\t\t\tlet form = document.querySelector(\"#passkey-login-form\");\n\t\t\t\tlet credAss = JSON.parse(form.dataset.credAss);\n\t\t\t\tcredAss.publicKey.challenge = decodebase64url(credAss.publicKey.challenge);\n\t\t\t\tfor (let ac of credAss.publicKey.allowCredentials) {\n\t\t\t\t\tac.id = decodebase64url(ac.id);\n\t\t\t\t}\n\t\t\t\tconsole.log(credAss);\n\t\t\t\tevent.preventDefault();\n\t\t\t\ttry {\n\t\t\t\t\tlet cred = await navigator.credentials.get(credAss);\n\t\t\t\t\tlet res = await fetch(\"/login/passkey/finish\", {\n\t\t\t\t\t\tmethod: \"post\",\n\t\t\t\t\t\theaders: { \"Content-Type\": \"application/json\" },\n\t\t\t\t\t\tbody: JSON.stringify({\n\t\t\t\t\t\t\tkthid: new FormData(form).get(\"kthid\"),\n\t\t\t\t\t\t\tcred: {\n\t\t\t\t\t\t\t\tid: cred.id,\n\t\t\t\t\t\t\t\trawId: encodebase64url(cred.rawId),\n\t\t\t\t\t\t\t\ttype: cred.type,\n\t\t\t\t\t\t\t\tauthenticatorAttachment: cred.authenticatorAttachment,\n\t\t\t\t\t\t\t\tresponse: {\n\t\t\t\t\t\t\t\t\tauthenticatorData: encodebase64url(cred.response.authenticatorData),\n\t\t\t\t\t\t\t\t\tclientDataJSON: encodebase64url(cred.response.clientDataJSON),\n\t\t\t\t\t\t\t\t\tsignature: encodebase64url(cred.response.signature),\n\t\t\t\t\t\t\t\t\tuserHandle: encodebase64url(cred.response.userHandle),\n\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t},\n\t\t\t\t\t\t}),\n\t\t\t\t\t});\n\t\t\t\t\tif (res.status == 200)\n\t\t\t\t\t\twindow.location.replace(\"/\");\n\t\t\t\t\telse\n\t\t\t\t\t\tthrow new Error(await res.text());\n\t\t\t\t} catch (err) {\n\t\t\t\t\tlet text = (err.name === \"NotAllowedError\")\n\t\t\t\t\t\t? \"Missing permission or request was cancelled\"\n\t\t\t\t\t\t: err.message;\n\t\t\t\t\tlet el = document.createElement(\"p\");\n\t\t\t\t\tel.classList.add(\"error\");\n\t\t\t\t\tel.textContent = text;\n\t\t\t\t\tform.appendChild(el);\n\t\t\t\t} finally {\n\t\t\t\t\tform.querySelector(\"button\").classList.remove(\"spinner\");\n\t\t\t\t}\n\t\t\t</script>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<script type=\"module\">\n\t\t\t\tlet form = document.querySelector(\"#passkey-login-form\");\n\t\t\t\tlet credAss = JSON.parse(form.dataset.credAss);\n\t\t\t\tcredAss.publicKey.challenge = decodebase64url(credAss.publicKey.challenge);\n\t\t\t\tfor (let ac of credAss.publicKey.allowCredentials) {\n\t\t\t\t\tac.id = decodebase64url(ac.id);\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\ttry {\n\t\t\t\t\tlet cred = await navigator.credentials.get(credAss);\n\t\t\t\t\tlet res = await fetch(\"/login/passkey/finish\", {\n\t\t\t\t\t\tmethod: \"post\",\n\t\t\t\t\t\theaders: { \"Content-Type\": \"application/json\" },\n\t\t\t\t\t\tbody: JSON.stringify({\n\t\t\t\t\t\t\tkthid: new FormData(form).get(\"kthid\"),\n\t\t\t\t\t\t\tcred: {\n\t\t\t\t\t\t\t\tid: cred.id,\n\t\t\t\t\t\t\t\trawId: encodebase64url(cred.rawId),\n\t\t\t\t\t\t\t\ttype: cred.type,\n\t\t\t\t\t\t\t\tauthenticatorAttachment: cred.authenticatorAttachment,\n\t\t\t\t\t\t\t\tresponse: {\n\t\t\t\t\t\t\t\t\tauthenticatorData: encodebase64url(cred.response.authenticatorData),\n\t\t\t\t\t\t\t\t\tclientDataJSON: encodebase64url(cred.response.clientDataJSON),\n\t\t\t\t\t\t\t\t\tsignature: encodebase64url(cred.response.signature),\n\t\t\t\t\t\t\t\t\tuserHandle: encodebase64url(cred.response.userHandle),\n\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t},\n\t\t\t\t\t\t}),\n\t\t\t\t\t});\n\t\t\t\t\tif (res.status == 200)\n\t\t\t\t\t\twindow.location.replace(\"/\");\n\t\t\t\t\telse\n\t\t\t\t\t\tthrow new Error(await res.text());\n\t\t\t\t} catch (err) {\n\t\t\t\t\tlet text = (err.name === \"NotAllowedError\")\n\t\t\t\t\t\t? \"Missing permission or request was cancelled\"\n\t\t\t\t\t\t: err.message;\n\t\t\t\t\tlet el = document.createElement(\"p\");\n\t\t\t\t\tel.classList.add(\"error\");\n\t\t\t\t\tel.textContent = text;\n\t\t\t\t\tform.appendChild(el);\n\t\t\t\t} finally {\n\t\t\t\t\tform.querySelector(\"button\").classList.remove(\"spinner\");\n\t\t\t\t}\n\t\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -72,7 +72,7 @@ func passkeyLogin(kthid string, credAss *protocol.CredentialAssertion) templ.Com
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(kthid)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 76, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 75, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -137,7 +137,7 @@ func showPasskey(passkey export.Passkey) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(passkey.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 98, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 97, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -150,7 +150,7 @@ func showPasskey(passkey export.Passkey) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs("/passkey/" + passkey.ID.String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 105, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 104, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -225,7 +225,7 @@ func addPasskeyForm(cc *protocol.CredentialCreation) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(templ.JSONString(cc))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 138, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `passkey.templ`, Line: 137, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {

--- a/services/static/public/hx-clone.js
+++ b/services/static/public/hx-clone.js
@@ -7,7 +7,6 @@ htmx.defineExtension('clone', {
                 const get = evt.detail.elt.getAttribute('hx-get')
                 if (get && get.startsWith('clone-template#')) {
                     const selector = get.substring(15)
-                    //console.log('htmx-clone: Intercepting xhr request to inject template with selector:', selector)
                     const template = document.querySelector(selector)
                     let templateContent = ''
                     if (!template) {

--- a/services/user/auth/auth.go
+++ b/services/user/auth/auth.go
@@ -2,11 +2,11 @@ package auth
 
 import "net/http"
 
-const SESSION_COOKIE string = "_logout_session"
+const SessionCookieName string = "_logout_session"
 
-func UserCookie(sessionID string) *http.Cookie {
+func SessionCookie(sessionID string) *http.Cookie {
 	return &http.Cookie{
-		Name:     SESSION_COOKIE,
+		Name:     SessionCookieName,
 		Value:    sessionID,
 		Path:     "/",
 		HttpOnly: true,

--- a/services/user/auth/auth.go
+++ b/services/user/auth/auth.go
@@ -1,3 +1,16 @@
 package auth
 
+import "net/http"
+
 const SESSION_COOKIE string = "_logout_session"
+
+func UserCookie(sessionID string) *http.Cookie {
+	return &http.Cookie{
+		Name:     SESSION_COOKIE,
+		Value:    sessionID,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	}
+}

--- a/services/user/auth/auth.go
+++ b/services/user/auth/auth.go
@@ -1,0 +1,3 @@
+package auth
+
+const SESSION_COOKIE string = "_logout_session"

--- a/services/user/handlers.go
+++ b/services/user/handlers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-const NEXT_URL_COOKIE string = "_logout_next-url"
+const nextUrlCookie string = "_logout_next-url"
 
 func (s *service) index(w http.ResponseWriter, r *http.Request) httputil.ToResponse {
 	returnURL := r.FormValue("next-url")
@@ -22,7 +22,7 @@ func (s *service) index(w http.ResponseWriter, r *http.Request) httputil.ToRespo
 	}
 	hasCookie := false
 	if returnURL == "" {
-		c, _ := r.Cookie(NEXT_URL_COOKIE)
+		c, _ := r.Cookie(nextUrlCookie)
 		if c != nil {
 			returnURL = c.Value
 			hasCookie = true
@@ -35,14 +35,14 @@ func (s *service) index(w http.ResponseWriter, r *http.Request) httputil.ToRespo
 		return err
 	} else if kthid != "" {
 		if hasCookie {
-			http.SetCookie(w, &http.Cookie{Name: NEXT_URL_COOKIE, MaxAge: -1})
+			http.SetCookie(w, &http.Cookie{Name: nextUrlCookie, MaxAge: -1})
 		}
 		http.Redirect(w, r, returnURL, http.StatusSeeOther)
 		return nil
 	}
 	if returnURL != "" {
 		http.SetCookie(w, &http.Cookie{
-			Name:     NEXT_URL_COOKIE,
+			Name:     nextUrlCookie,
 			Value:    returnURL,
 			MaxAge:   int((time.Minute * 10).Seconds()),
 			Secure:   true,

--- a/services/user/handlers.go
+++ b/services/user/handlers.go
@@ -13,6 +13,8 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+const NEXT_URL_COOKIE string = "_logout_next-url"
+
 func (s *service) index(w http.ResponseWriter, r *http.Request) httputil.ToResponse {
 	returnURL := r.FormValue("next-url")
 	if returnURL != "" && returnURL[0] != '/' {
@@ -20,7 +22,7 @@ func (s *service) index(w http.ResponseWriter, r *http.Request) httputil.ToRespo
 	}
 	hasCookie := false
 	if returnURL == "" {
-		c, _ := r.Cookie("next-url")
+		c, _ := r.Cookie(NEXT_URL_COOKIE)
 		if c != nil {
 			returnURL = c.Value
 			hasCookie = true
@@ -33,14 +35,14 @@ func (s *service) index(w http.ResponseWriter, r *http.Request) httputil.ToRespo
 		return err
 	} else if kthid != "" {
 		if hasCookie {
-			http.SetCookie(w, &http.Cookie{Name: "next-url", MaxAge: -1})
+			http.SetCookie(w, &http.Cookie{Name: NEXT_URL_COOKIE, MaxAge: -1})
 		}
 		http.Redirect(w, r, returnURL, http.StatusSeeOther)
 		return nil
 	}
 	if returnURL != "" {
 		http.SetCookie(w, &http.Cookie{
-			Name:     "next-url",
+			Name:     NEXT_URL_COOKIE,
 			Value:    returnURL,
 			MaxAge:   int((time.Minute * 10).Seconds()),
 			Secure:   true,

--- a/services/user/user.go
+++ b/services/user/user.go
@@ -9,6 +9,7 @@ import (
 	"github.com/datasektionen/logout/pkg/httputil"
 	dev "github.com/datasektionen/logout/services/dev/export"
 	passkey "github.com/datasektionen/logout/services/passkey/export"
+	"github.com/datasektionen/logout/services/user/auth"
 	"github.com/datasektionen/logout/services/user/export"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -71,7 +72,7 @@ func (s *service) LoginUser(ctx context.Context, kthid string) httputil.ToRespon
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.SetCookie(w, &http.Cookie{
-			Name:     "session",
+			Name:     auth.SESSION_COOKIE,
 			Value:    sessionID.String(),
 			Path:     "/",
 			HttpOnly: true,
@@ -83,7 +84,7 @@ func (s *service) LoginUser(ctx context.Context, kthid string) httputil.ToRespon
 }
 
 func (s *service) GetLoggedInKTHID(r *http.Request) (string, error) {
-	sessionCookie, _ := r.Cookie("session")
+	sessionCookie, _ := r.Cookie(auth.SESSION_COOKIE)
 	if sessionCookie == nil {
 		return "", nil
 	}
@@ -113,7 +114,7 @@ func (s *service) GetLoggedInUser(r *http.Request) (*export.User, error) {
 }
 
 func (s *service) Logout(w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	sessionCookie, _ := r.Cookie("session")
+	sessionCookie, _ := r.Cookie(auth.SESSION_COOKIE)
 	if sessionCookie != nil {
 		sessionID, err := uuid.Parse(sessionCookie.Value)
 		if err != nil {
@@ -122,7 +123,7 @@ func (s *service) Logout(w http.ResponseWriter, r *http.Request) httputil.ToResp
 			}
 		}
 	}
-	http.SetCookie(w, &http.Cookie{Name: "session", MaxAge: -1})
+	http.SetCookie(w, &http.Cookie{Name: auth.SESSION_COOKIE, MaxAge: -1})
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 	return nil
 }

--- a/services/user/user.go
+++ b/services/user/user.go
@@ -71,13 +71,13 @@ func (s *service) LoginUser(ctx context.Context, kthid string) httputil.ToRespon
 		return err
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.SetCookie(w, auth.UserCookie(sessionID.String()))
+		http.SetCookie(w, auth.SessionCookie(sessionID.String()))
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	})
 }
 
 func (s *service) GetLoggedInKTHID(r *http.Request) (string, error) {
-	sessionCookie, _ := r.Cookie(auth.SESSION_COOKIE)
+	sessionCookie, _ := r.Cookie(auth.SessionCookieName)
 	if sessionCookie == nil {
 		return "", nil
 	}
@@ -107,7 +107,7 @@ func (s *service) GetLoggedInUser(r *http.Request) (*export.User, error) {
 }
 
 func (s *service) Logout(w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	sessionCookie, _ := r.Cookie(auth.SESSION_COOKIE)
+	sessionCookie, _ := r.Cookie(auth.SessionCookieName)
 	if sessionCookie != nil {
 		sessionID, err := uuid.Parse(sessionCookie.Value)
 		if err != nil {
@@ -116,7 +116,7 @@ func (s *service) Logout(w http.ResponseWriter, r *http.Request) httputil.ToResp
 			}
 		}
 	}
-	http.SetCookie(w, &http.Cookie{Name: auth.SESSION_COOKIE, MaxAge: -1})
+	http.SetCookie(w, &http.Cookie{Name: auth.SessionCookieName, MaxAge: -1})
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 	return nil
 }

--- a/services/user/user.go
+++ b/services/user/user.go
@@ -71,14 +71,7 @@ func (s *service) LoginUser(ctx context.Context, kthid string) httputil.ToRespon
 		return err
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.SetCookie(w, &http.Cookie{
-			Name:     auth.SESSION_COOKIE,
-			Value:    sessionID.String(),
-			Path:     "/",
-			HttpOnly: true,
-			Secure:   true,
-			SameSite: http.SameSiteLaxMode,
-		})
+		http.SetCookie(w, auth.UserCookie(sessionID.String()))
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	})
 }


### PR DESCRIPTION
When logging in via passcode, a `fetch` request would be made to `/login/passkey/finish`, which in turn would redirect to the callback URL, resulting in a CORS error.

This fixes this by just updating the session cookie from this request. When the browser then redirects to `/`, the user will then already be logged in and redirected to the callback URL. Also renamed the cookie values to something more unique to logout :)